### PR TITLE
Add Plaid API integration for automated transaction fetching

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -30,3 +30,34 @@ budget.opening.balance.cc2=165.35
 
 # ── Budget categories (comma-separated, must match Ledger sheet header row) ──
 budget.categories=Bills/Rent,Groceries,Restaurants,Car/Gas,Subscriptions,Entertainment,Tech,Health/Fitness,Medical,Dispensary,Pets,Investments,Merchandise,Other
+
+# ── Plaid integration (optional — replaces manual CSV downloads) ─────────────
+# Set plaid.enabled=true to fetch transactions directly from your banks via Plaid.
+# When enabled, budget.statements.dir is not required.
+#
+# Setup steps:
+#   1. Create a free developer account at https://dashboard.plaid.com
+#   2. Copy your client_id and secret from the dashboard
+#   3. Run Plaid Link once per institution to get access tokens:
+#      - Use the Plaid Quickstart (https://github.com/plaid/quickstart) locally, or
+#      - Use sandbox test tokens: access-sandbox-<uuid> (for testing)
+#   4. After linking, find account IDs by calling /accounts/get with each access token
+#      and match the IDs to your two Discover cards
+#
+plaid.enabled=false
+plaid.environment=sandbox
+plaid.client.id=
+plaid.secret=
+
+# One access token per institution (obtained via Plaid Link)
+plaid.access.token.elfcu=
+plaid.access.token.chase=
+plaid.access.token.discover=
+
+# Plaid account IDs for your two Discover cards (from /accounts/get response)
+# Required to distinguish CC 1 (9577) from CC 2 (4914) within the same Discover connection
+plaid.account.id.cc1=
+plaid.account.id.cc2=
+
+# How many days back to fetch (default: 30)
+plaid.days=30

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.18.2</version>
         </dependency>
+        <!-- Plaid Java SDK for bank account connectivity -->
+        <dependency>
+            <groupId>com.plaid</groupId>
+            <artifactId>plaid-java</artifactId>
+            <version>27.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/noslen/transaction_reader/TransactionReaderApplication.java
+++ b/src/main/java/com/noslen/transaction_reader/TransactionReaderApplication.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.*;
 
 public class TransactionReaderApplication {
@@ -30,16 +31,22 @@ public class TransactionReaderApplication {
         }
 
         try {
-            // ── Step 1: Discover statement files ─────────────────────────────
-            Map<String, List<String>> statementFiles = discoverStatements(config.getStatementsDir());
-            logger.info("Found statement files: {}", statementFiles);
-
-            // ── Step 2: Parse all statements ──────────────────────────────────
+            // ── Step 1 & 2: Fetch transactions (Plaid API or local CSV files) ─
             List<Transaction> allTransactions = new ArrayList<>();
-            allTransactions.addAll(parseWith(new ElfcuParser(),    statementFiles.get("ELFCU")));
-            allTransactions.addAll(parseWith(new ChaseParser(),    statementFiles.get("Chase")));
-            allTransactions.addAll(parseWith(new DiscoverParser(), statementFiles.get("Discover")));
-            logger.info("Parsed {} total transactions.", allTransactions.size());
+
+            if (config.isPlaidEnabled()) {
+                logger.info("Plaid mode enabled — fetching transactions from API.");
+                LocalDate endDate   = LocalDate.now();
+                LocalDate startDate = endDate.minusDays(config.getPlaidDays());
+                allTransactions.addAll(new PlaidClient(config).fetchTransactions(startDate, endDate));
+            } else {
+                Map<String, List<String>> statementFiles = discoverStatements(config.getStatementsDir());
+                logger.info("Found statement files: {}", statementFiles);
+                allTransactions.addAll(parseWith(new ElfcuParser(),    statementFiles.get("ELFCU")));
+                allTransactions.addAll(parseWith(new ChaseParser(),    statementFiles.get("Chase")));
+                allTransactions.addAll(parseWith(new DiscoverParser(), statementFiles.get("Discover")));
+            }
+            logger.info("Loaded {} total transactions.", allTransactions.size());
 
             if (allTransactions.isEmpty()) {
                 logger.warn("No transactions found — nothing to write.");

--- a/src/main/java/com/noslen/transaction_reader/config/Config.java
+++ b/src/main/java/com/noslen/transaction_reader/config/Config.java
@@ -6,10 +6,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;;
 
 /**
  * Reads configuration from {@code config.properties} in the working directory,
@@ -39,12 +36,30 @@ public class Config {
     // Category list (expense categories only — matches Ledger header columns I–V)
     private final List<String> categoryList;
 
+    // Plaid
+    private final boolean plaidEnabled;
+    private final String plaidClientId;
+    private final String plaidSecret;
+    private final String plaidEnvironment;
+    private final String plaidAccessTokenElfcu;
+    private final String plaidAccessTokenChase;
+    private final String plaidAccessTokenDiscover;
+    private final String plaidAccountIdCc1;
+    private final String plaidAccountIdCc2;
+    private final int plaidDays;
+
     private Config() {
         Properties props = loadPropertiesFile();
 
+        String plaidEnabledRaw = get(props, "PLAID_ENABLED", "plaid.enabled", "false");
+        this.plaidEnabled = "true".equalsIgnoreCase(plaidEnabledRaw);
+
         this.initialExcelPath = require(props, "BUDGET_EXCEL_FILE",    "budget.excel.path");
         this.outputPath       = get(props,     "OUTPUT_FILE",           "budget.output.path", initialExcelPath);
-        this.statementsDir    = require(props, "STATEMENTS_DIR",        "budget.statements.dir");
+        // statementsDir not required when Plaid is the data source
+        this.statementsDir    = plaidEnabled
+                ? get(props,     "STATEMENTS_DIR", "budget.statements.dir", null)
+                : require(props, "STATEMENTS_DIR", "budget.statements.dir");
         this.merchantsPath    = require(props, "MERCHANTS_FILE",        "budget.merchants.path");
 
         this.openingBalanceElfcu  = getDouble(props, "OPENING_BALANCE_ELFCU",  "budget.opening.balance.elfcu",  178.33);
@@ -56,6 +71,21 @@ public class Config {
                 "Bills/Rent,Groceries,Restaurants,Car/Gas,Subscriptions,Entertainment," +
                 "Tech,Health/Fitness,Medical,Dispensary,Pets,Investments,Merchandise,Other");
         this.categoryList = Arrays.asList(cats.split(","));
+
+        this.plaidClientId          = get(props, "PLAID_CLIENT_ID",           "plaid.client.id",               null);
+        this.plaidSecret            = get(props, "PLAID_SECRET",              "plaid.secret",                  null);
+        this.plaidEnvironment       = get(props, "PLAID_ENVIRONMENT",         "plaid.environment",             "sandbox");
+        this.plaidAccessTokenElfcu  = get(props, "PLAID_ACCESS_TOKEN_ELFCU",  "plaid.access.token.elfcu",      null);
+        this.plaidAccessTokenChase  = get(props, "PLAID_ACCESS_TOKEN_CHASE",  "plaid.access.token.chase",      null);
+        this.plaidAccessTokenDiscover = get(props, "PLAID_ACCESS_TOKEN_DISCOVER", "plaid.access.token.discover", null);
+        this.plaidAccountIdCc1      = get(props, "PLAID_ACCOUNT_ID_CC1",      "plaid.account.id.cc1",          null);
+        this.plaidAccountIdCc2      = get(props, "PLAID_ACCOUNT_ID_CC2",      "plaid.account.id.cc2",          null);
+        this.plaidDays              = (int) getDouble(props, "PLAID_DAYS",    "plaid.days",                    30.0);
+
+        if (plaidEnabled) {
+            requireNotNull(plaidClientId, "PLAID_CLIENT_ID",  "plaid.client.id");
+            requireNotNull(plaidSecret,   "PLAID_SECRET",     "plaid.secret");
+        }
     }
 
     public static Config getInstance() {
@@ -84,6 +114,29 @@ public class Config {
     // Keep for backward compat with CliService
     public String getInputPath() { return statementsDir; }
 
+    public boolean isPlaidEnabled()      { return plaidEnabled; }
+    public String getPlaidClientId()     { return plaidClientId; }
+    public String getPlaidSecret()       { return plaidSecret; }
+    public String getPlaidEnvironment()  { return plaidEnvironment; }
+    public int getPlaidDays()            { return plaidDays; }
+
+    /** Returns a label→accessToken map for each configured institution. */
+    public Map<String, String> getPlaidAccessTokens() {
+        Map<String, String> tokens = new LinkedHashMap<>();
+        if (plaidAccessTokenElfcu     != null) tokens.put("ELFCU",    plaidAccessTokenElfcu);
+        if (plaidAccessTokenChase     != null) tokens.put("Chase",    plaidAccessTokenChase);
+        if (plaidAccessTokenDiscover  != null) tokens.put("Discover", plaidAccessTokenDiscover);
+        return tokens;
+    }
+
+    /** Returns a Plaid accountId→our account name map for disambiguation (e.g. two Discover cards). */
+    public Map<String, String> getPlaidAccountIdMap() {
+        Map<String, String> map = new HashMap<>();
+        if (plaidAccountIdCc1 != null) map.put(plaidAccountIdCc1, "CC 1");
+        if (plaidAccountIdCc2 != null) map.put(plaidAccountIdCc2, "CC 2");
+        return map;
+    }
+
     // ── internals ────────────────────────────────────────────────────────────
 
     private Properties loadPropertiesFile() {
@@ -100,6 +153,14 @@ public class Config {
             logger.info("No config.properties found — relying on environment variables.");
         }
         return props;
+    }
+
+    private void requireNotNull(String value, String envKey, String propKey) {
+        if (value == null) {
+            throw new IllegalStateException(
+                "Missing required Plaid config: set env var '" + envKey +
+                "' or add '" + propKey + "' to config.properties");
+        }
     }
 
     /** env var takes precedence; then props file; then throws if missing. */

--- a/src/main/java/com/noslen/transaction_reader/io/PlaidClient.java
+++ b/src/main/java/com/noslen/transaction_reader/io/PlaidClient.java
@@ -1,0 +1,98 @@
+package com.noslen.transaction_reader.io;
+
+import com.noslen.transaction_reader.config.Config;
+import com.noslen.transaction_reader.model.Transaction;
+import com.plaid.client.ApiClient;
+import com.plaid.client.model.TransactionsGetRequest;
+import com.plaid.client.model.TransactionsGetResponse;
+import com.plaid.client.request.PlaidApi;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.*;
+
+public class PlaidClient {
+
+    private static final Logger logger = LogManager.getLogger(PlaidClient.class);
+
+    private final PlaidApi plaidApi;
+    private final Map<String, String> accessTokens;
+    private final Map<String, String> accountIdToName;
+
+    public PlaidClient(Config config) {
+        HashMap<String, String> apiKeys = new HashMap<>();
+        apiKeys.put("clientId", config.getPlaidClientId());
+        apiKeys.put("secret", config.getPlaidSecret());
+
+        ApiClient apiClient = new ApiClient(apiKeys);
+        apiClient.setPlaidAdapter(resolveEnvironment(config.getPlaidEnvironment()));
+        this.plaidApi = apiClient.createService(PlaidApi.class);
+
+        this.accessTokens    = config.getPlaidAccessTokens();
+        this.accountIdToName = config.getPlaidAccountIdMap();
+    }
+
+    public List<Transaction> fetchTransactions(LocalDate startDate, LocalDate endDate) throws IOException {
+        List<Transaction> all = new ArrayList<>();
+        for (Map.Entry<String, String> entry : accessTokens.entrySet()) {
+            String institutionLabel = entry.getKey();
+            String accessToken = entry.getValue();
+            logger.info("Fetching Plaid transactions for {} ({} to {})", institutionLabel, startDate, endDate);
+            all.addAll(fetchForToken(accessToken, institutionLabel, startDate, endDate));
+        }
+        return all;
+    }
+
+    private List<Transaction> fetchForToken(String accessToken, String institutionLabel,
+                                             LocalDate startDate, LocalDate endDate) throws IOException {
+        TransactionsGetRequest request = new TransactionsGetRequest()
+                .accessToken(accessToken)
+                .startDate(startDate)
+                .endDate(endDate);
+
+        Response<TransactionsGetResponse> response = plaidApi.transactionsGet(request).execute();
+        if (!response.isSuccessful() || response.body() == null) {
+            logger.error("Plaid API error for {}: HTTP {}", institutionLabel, response.code());
+            return Collections.emptyList();
+        }
+
+        List<com.plaid.client.model.Transaction> plaidTxns = response.body().getTransactions();
+        logger.info("Received {} transactions from Plaid for {}", plaidTxns.size(), institutionLabel);
+        return mapTransactions(plaidTxns, institutionLabel);
+    }
+
+    private List<Transaction> mapTransactions(
+            List<com.plaid.client.model.Transaction> plaidTxns, String institutionLabel) {
+
+        List<Transaction> result = new ArrayList<>();
+        for (com.plaid.client.model.Transaction t : plaidTxns) {
+            // Discover: both cards share one access token; account ID disambiguates CC 1 vs CC 2.
+            // For single-card institutions (ELFCU, Chase) the map is empty so institutionLabel is used.
+            String accountName = accountIdToName.getOrDefault(t.getAccountId(), institutionLabel);
+
+            // Plaid convention: positive amount = money leaving the account (debit),
+            //                   negative amount = money entering the account (credit).
+            double amount = t.getAmount() != null ? t.getAmount() : 0.0;
+            double debit  = amount > 0 ?  amount : 0.0;
+            double credit = amount < 0 ? -amount : 0.0;
+
+            result.add(new Transaction(
+                    t.getDate(),
+                    t.getName(),
+                    debit,
+                    credit,
+                    0.0,
+                    accountName
+            ));
+        }
+        return result;
+    }
+
+    private static String resolveEnvironment(String env) {
+        if ("production".equalsIgnoreCase(env)) return ApiClient.Production;
+        return ApiClient.Sandbox;
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds optional Plaid API integration to fetch transactions directly from connected bank accounts, eliminating the need for manual CSV statement downloads. Users can now toggle between Plaid mode and the existing CSV-based workflow via configuration.

## Key Changes
- **New PlaidClient class** (`src/main/java/com/noslen/transaction_reader/io/PlaidClient.java`): Handles all Plaid API interactions
  - Fetches transactions for multiple institutions via their access tokens
  - Maps Plaid transaction data to the internal Transaction model
  - Converts Plaid's amount convention (positive=debit, negative=credit) to the application's format
  - Supports account ID mapping to disambiguate multiple cards from the same institution (e.g., two Discover cards)

- **Config enhancements** (`src/main/java/com/noslen/transaction_reader/config/Config.java`):
  - Added Plaid configuration properties (client ID, secret, environment, access tokens, account IDs, lookback period)
  - Made `statementsDir` optional when Plaid is enabled
  - Added validation to require Plaid credentials when `plaid.enabled=true`
  - New getter methods: `isPlaidEnabled()`, `getPlaidAccessTokens()`, `getPlaidAccountIdMap()`, etc.

- **Application flow update** (`src/main/java/com/noslen/transaction_reader/TransactionReaderApplication.java`):
  - Conditional logic to use Plaid API or CSV parsing based on configuration
  - Calculates date range for Plaid queries (configurable lookback period, default 30 days)
  - Maintains backward compatibility with existing CSV workflow

- **Configuration template** (`config.properties.template`):
  - Added comprehensive Plaid section with setup instructions
  - Documented required fields and optional account ID mappings
  - Included guidance for obtaining credentials and access tokens

- **Dependency addition** (`pom.xml`):
  - Added `plaid-java` SDK (v27.0.0) for API client functionality

## Notable Implementation Details
- Plaid mode is opt-in (`plaid.enabled=false` by default) to maintain backward compatibility
- Access tokens are stored per institution label (ELFCU, Chase, Discover) for flexible multi-institution support
- Account ID mapping allows distinguishing between multiple cards from the same institution without requiring separate access tokens
- Error handling gracefully returns empty transaction list on API failures rather than crashing
- Logging provides visibility into which institutions are being queried and transaction counts received

https://claude.ai/code/session_01BfG441ZnpdQ28BXfVyq2xt